### PR TITLE
Update token and presale contracts

### DIFF
--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -22,13 +22,13 @@ contract Presale is Haltable {
   uint256 constant public startTime = 1511892000; // 28 Nov 2017 @ 18:00   (UTC)
   uint256 constant public endTime =   1513641600; // 19 Dec 2017 @ 12:00am (UTC)
 
-  uint256 constant public tokenCap = uint256(10*1e6*1e8);
+  uint256 constant public tokenCap = uint256(8*1e6*1e8);
 
   // address where funds will be transfered
   address public withdrawAddress;
 
   // how many weis buyer need to pay for one token unit
-  uint256 public default_rate = 2000000;
+  uint256 public default_rate = 2500000;
 
   // amount of raised money in wei
   uint256 public weiRaised;
@@ -67,10 +67,10 @@ contract Presale is Haltable {
   }
 
   function initiate() public onlyOwner {
-    require(token.balanceOf(this) >= 10*uint256(10)**(6+8));
+    require(token.balanceOf(this) >= tokenCap);
     initiated = true;
-    if(token.balanceOf(this)>10*uint256(10)**(6+8))
-      require(token.transfer(withdrawAddress, token.balanceOf(this).sub(10*uint256(10)**(6+8))));
+    if(token.balanceOf(this)>tokenCap)
+      require(token.transfer(withdrawAddress, token.balanceOf(this).sub(tokenCap)));
   }
 
   // fallback function can be used to buy tokens

--- a/contracts/Presale.sol
+++ b/contracts/Presale.sol
@@ -148,8 +148,16 @@ contract Presale is Haltable {
 
   function finalize() public inState(State.Success) onlyOwner stopInEmergency {
     require(!finalized);
-    withdrawAddress.transfer(weiRaised);
+    require(this.balance==0);
     finalized = true;
+  }
+
+  function withdraw() public  inState(State.Success) onlyOwner stopInEmergency {
+    withdrawAddress.transfer(weiRaised);
+  }
+
+  function manualWithdrawal(uint256 _amount) public  inState(State.Success) onlyOwner stopInEmergency {
+    withdrawAddress.transfer(_amount);
   }
 
   function emergencyWithdrawal(uint256 _amount) public onlyOwner onlyInEmergency {

--- a/contracts/TakeProfitToken.sol
+++ b/contracts/TakeProfitToken.sol
@@ -15,7 +15,7 @@ contract TakeProfitToken is Token, Haltable {
 
 
     uint256 constant private UNIT = uint256(10)**decimals;
-    uint256 public totalSupply = 10**7 * UNIT;
+    uint256 public totalSupply = 10**8 * UNIT;
 
     uint256 constant MAX_UINT256 = 2**256 - 1; // Used for allowance: this value mean infinite allowance
 

--- a/contracts/TakeProfitToken.sol
+++ b/contracts/TakeProfitToken.sol
@@ -10,11 +10,11 @@ contract TakeProfitToken is Token, Haltable {
 
     string constant public name = "TakeProfit";
     uint8 constant public decimals = 8;
-    string constant public symbol = "TP";       
+    string constant public symbol = "XTP";       
     string constant public version = "1.1";
 
 
-    uint256 constant private UNIT = uint256(10)**decimals;
+    uint256 constant public UNIT = uint256(10)**decimals;
     uint256 public totalSupply = 10**8 * UNIT;
 
     uint256 constant MAX_UINT256 = 2**256 - 1; // Used for allowance: this value mean infinite allowance

--- a/test/erc20.js
+++ b/test/erc20.js
@@ -8,33 +8,35 @@ var TPToken = artifacts.require("./TakeProfitToken.sol");
 contract('TakeProfitToken(ERC20 checks)', function(accounts) {
 
   let token;
+  let totalSupply = 100*1e6*1e8; //100 milions tokens
 
   beforeEach(async function() {
     token = await TPToken.new();
   });
 
-  it("should put 1e7 TP in the owner account", async function() {
+  it("should put 1e8 TP in the owner account", async function() {
     var token = await TPToken.new();
     var balance = await token.balanceOf.call(accounts[0]);
-    assert.equal(balance.valueOf(), 1e7*1e8, "10 000 000 wasn't in the owner account");
+    assert.equal(balance.valueOf(), totalSupply, "100 000 000 wasn't in the owner account");
   });
 
 
   it("should return the correct totalSupply after construction", async function() {
     let totalSupply = await token.totalSupply();
-    assert.equal(totalSupply, 1e7*1e8, "Total supply isn't equal to 10 000 000");
+    assert.equal(totalSupply, totalSupply, "Total supply isn't equal to 100 000 000");
   })
 
   it("should return correct balances after transfer", async function(){
-    let transfer = await token.transfer(accounts[1], 1e7*1e8, {from: accounts[0]});
+    let transfer = await token.transfer(accounts[1], totalSupply, {from: accounts[0]});
     let firstAccountBalance = await token.balanceOf(accounts[0]);
     assert.equal(firstAccountBalance, 0);
     let secondAccountBalance = await token.balanceOf(accounts[1]);
-    assert.equal(secondAccountBalance, 1e7*1e8);
+    assert.equal(secondAccountBalance, totalSupply);
   });
 
   it('should throw an error when trying to transfer more than balance', async function() {
-    await expectThrow(token.transfer(accounts[1], 1e7*1e8+1, {from: accounts[0]}));
+    var balance = await token.balanceOf.call(accounts[0]);
+    await expectThrow(token.transfer(accounts[1], balance.plus(1), {from: accounts[0]}));
   });
 
   it('should throw an error when trying to transfer to 0x0', async function() {
@@ -52,7 +54,7 @@ contract('TakeProfitToken(ERC20 checks)', function(accounts) {
     await token.transferFrom(accounts[0], accounts[2], 100, {from: accounts[1]});
 
     let balance0 = await token.balanceOf(accounts[0]);
-    assert.equal(balance0, 1e7*1e8-100);
+    assert.equal(balance0, totalSupply-100);
 
     let balance1 = await token.balanceOf(accounts[2]);
     assert.equal(balance1, 100);

--- a/test/presale.js
+++ b/test/presale.js
@@ -60,8 +60,8 @@ contract('Presale', function(accounts) {
   let nonowner2 = accounts[4];
   let nonowner3 = accounts[5];
 
-  let start_time = 1511287200;
-  let finish_time = 1513814400;
+  let start_time = 1511892000; // 28 November 6 pm
+  let finish_time = 1513641600; // 19 December
   let rate = 1e6*1e8/(2e3*1e18);
 
   var token, presale;

--- a/test/presale.js
+++ b/test/presale.js
@@ -62,7 +62,7 @@ contract('Presale', function(accounts) {
 
   let start_time = 1511892000; // 28 November 6 pm
   let finish_time = 1513641600; // 19 December
-  let default_rate = 10*1e6*1e8/(2e3*1e18);
+  let default_rate = 8*1e6*1e8/(2e3*1e18);
   let first_week_rate = 2*default_rate;
   let second_week_rate = 1./Math.floor(1/(1.9*default_rate));
   let third_week_rate = 1./Math.floor(1/(1.8*default_rate));
@@ -114,7 +114,7 @@ contract('Presale', function(accounts) {
 
   it("should return excess of tokens to withdrawer", async function() {
     await revertToSnapshot(compiled_snapshot);
-    await token.transfer(presale.address, (new web3.BigNumber(10*1e6*1e8)).plus(10),{from: token_owner});
+    await token.transfer(presale.address, (new web3.BigNumber(8*1e6*1e8)).plus(10),{from: token_owner});
     await presale.initiate({from:owner});
     initialised_snapshot = await getSnapshot();
 
@@ -273,7 +273,7 @@ contract('Presale', function(accounts) {
     await expectThrow(presale.withdraw({from:nonowner1}));
     await presale.withdraw({from:owner});
     final_balance = await getBalance(withdrawer);
-    assert.equal(initial_balance.plus( new web3.BigNumber("1038888690833254970720")).toPrecision(25), final_balance.toPrecision(25), "Incorrectly transfer raised money");
+    assert.equal(initial_balance.plus( new web3.BigNumber("1038888622000031960129")).toPrecision(25), final_balance.toPrecision(25), "Incorrectly transfer raised money");
  
   });
 
@@ -336,7 +336,7 @@ contract('Presale', function(accounts) {
 
     initial_token_balance = await token.balanceOf.call(nonowner1);
     await presale.claim({from: nonowner1});
-    assert.equal((await token.balanceOf.call(nonowner1)).minus(initial_token_balance).toNumber(), 5*1e6*1e8, "Incorrectly transfer purchased coins");    
+    assert.equal((await token.balanceOf.call(nonowner1)).minus(initial_token_balance).toNumber(), 4*1e6*1e8, "Incorrectly transfer purchased coins");    
   });
 
   it("should transfer claimed tokens only once", async function() {
@@ -345,7 +345,7 @@ contract('Presale', function(accounts) {
     initial_token_balance = await token.balanceOf.call(nonowner1);
     await presale.claim({from: nonowner1});
     await expectThrow(presale.claim({from: nonowner1}));
-    assert.equal((await token.balanceOf.call(nonowner1)).minus(initial_token_balance).toNumber(), 5*1e6*1e8, "Incorrectly transfer purchased coins");    
+    assert.equal((await token.balanceOf.call(nonowner1)).minus(initial_token_balance).toNumber(), 4*1e6*1e8, "Incorrectly transfer purchased coins");    
   });
 
   it("should transfer claimed coins(delegated)", async function() {
@@ -353,7 +353,7 @@ contract('Presale', function(accounts) {
 
     initial_token_balance = await token.balanceOf.call(nonowner1);
     await presale.claimTokens(nonowner1, {from: nonowner2});
-    assert.equal((await token.balanceOf.call(nonowner1)).minus(initial_token_balance).toNumber(), 5*1e6*1e8, "Incorrectly transfer purchased coins");    
+    assert.equal((await token.balanceOf.call(nonowner1)).minus(initial_token_balance).toNumber(), 4*1e6*1e8, "Incorrectly transfer purchased coins");    
   });
 
   it("should correctly pass to Refunding state", async function() {

--- a/test/presale.js
+++ b/test/presale.js
@@ -105,18 +105,18 @@ contract('Presale', function(accounts) {
 
   it("should not allow initialisation for non-owner", async function() {
     await revertToSnapshot(compiled_snapshot);
-    await token.transfer(presale.address, 100000000000000,{from: token_owner});
-    await expectThrow(presale.initiate({from:nonowner1})); //still not enough
+    await token.transfer(presale.address, 100*1e6*1e8,{from: token_owner});
+    await expectThrow(presale.initiate({from:nonowner1}));
   });
 
   it("should return excess of tokens to withdrawer", async function() {
     await revertToSnapshot(compiled_snapshot);
-    await token.transfer(presale.address, 100000000000010,{from: token_owner});
+    await token.transfer(presale.address, (new web3.BigNumber(10*1e6*1e8)).plus(10),{from: token_owner});
     await presale.initiate({from:owner});
     initialised_snapshot = await getSnapshot();
 
     assert.equal(await presale.getState.call(), 2, "Incorrectly determined state");
-    assert.equal(await token.balanceOf.call(withdrawer), 10, "Incorrectly return excesses to withdrawer");
+    assert.equal((await token.balanceOf.call(withdrawer)).toNumber(), 10, "Incorrectly return excesses to withdrawer");
   });
 
   it("should correctly pass to prefunding", async function() {

--- a/test/token.js
+++ b/test/token.js
@@ -4,10 +4,10 @@ require('babel-polyfill');
 var TPToken = artifacts.require("./TakeProfitToken.sol");
 
 contract('TakeProfitToken', function(accounts) {
-  it("should put 1e7 TP in the owner account", async function() {
+  it("should put 100m TP in the owner account", async function() {
     var token = await TPToken.new();
     var balance = await token.balanceOf.call(accounts[0]);
-    assert.equal(balance.valueOf(), 1e7*1e8, "10 000 000 wasn't in the owner account");
+    assert.equal(balance.valueOf(), 100*1e6*1e8, "100 000 000 wasn't in the owner account");
   });
   
   it("should send coin correctly", async function() {

--- a/test/token.js
+++ b/test/token.js
@@ -7,7 +7,9 @@ contract('TakeProfitToken', function(accounts) {
   it("should put 100m TP in the owner account", async function() {
     var token = await TPToken.new();
     var balance = await token.balanceOf.call(accounts[0]);
-    assert.equal(balance.valueOf(), 100*1e6*1e8, "100 000 000 wasn't in the owner account");
+    assert.equal(await token.decimals.call(), 8, "Incorrect decimals");
+    assert.equal(await token.UNIT.call(), 1e8, "Incorrect UNIT");
+    assert.equal(balance.valueOf(), 100*1e6*(await token.UNIT.call()), "100 000 000 wasn't in the owner account");
   });
   
   it("should send coin correctly", async function() {
@@ -60,6 +62,13 @@ contract('TakeProfitToken', function(accounts) {
 
       assert.equal(balance_final_0, balance_initial_0 - amount, "Amount wasn't correctly taken from the sender");
       assert.equal(balance_final_1, balance_initial_1 + amount, "Amount wasn't correctly sent to the receiver");
+  });
+
+  it("should have correct name and ticker", async function() {
+      var token = await TPToken.new();
+
+      assert.equal(await token.name.call(), "TakeProfit", "Incorrect name");
+      assert.equal(await token.symbol.call(), "XTP", "Incorrect ticker");
   });
 
 });


### PR DESCRIPTION
- Token ticker updated to `XTP`
- Total number of tokens increased to 100m
- Total number of tokens for presale increased to 8m
- Updated start and finish dates: 28 Nov and 19 Dec
- Default rate decreased to 2500 000 Wei per unit (250 ether for 1m XTP)
- Variable presale rate: 100% bonus on first week, 90% on second and 80% on third